### PR TITLE
Tighten typography and fix filters collapse

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,65 +4,35 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 0 0% 3.9%;
+    --background: 222 40% 6%;
+    --foreground: 214 45% 94%;
 
-    --card: 0 0% 100%;
-    --card-foreground: 0 0% 3.9%;
+    --card: 221 32% 10%;
+    --card-foreground: 214 45% 94%;
 
-    --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 3.9%;
+    --popover: 221 32% 10%;
+    --popover-foreground: 214 45% 94%;
 
-    --primary: 0 0% 9%;
-    --primary-foreground: 0 0% 98%;
+    --primary: 160 84% 58%;
+    --primary-foreground: 222 47% 7%;
 
-    --secondary: 0 0% 96.1%;
-    --secondary-foreground: 0 0% 9%;
+    --secondary: 224 28% 16%;
+    --secondary-foreground: 214 45% 94%;
 
-    --muted: 0 0% 96.1%;
-    --muted-foreground: 0 0% 45.1%;
+    --muted: 222 24% 20%;
+    --muted-foreground: 215 16% 72%;
 
-    --accent: 0 0% 96.1%;
-    --accent-foreground: 0 0% 9%;
+    --accent: 201 94% 68%;
+    --accent-foreground: 214 45% 94%;
 
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
+    --destructive: 0 84% 60%;
+    --destructive-foreground: 210 40% 98%;
 
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
-    --ring: 0 0% 3.9%;
+    --border: 222 28% 22%;
+    --input: 222 28% 20%;
+    --ring: 161 82% 60%;
 
-    --radius: 0.5rem;
-  }
-
-  .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
-
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
-
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
-
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
-
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
-
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
-
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
-
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
+    --radius: 1rem;
   }
 }
 
@@ -72,5 +42,20 @@
   }
   body {
     @apply bg-background text-foreground;
+    background-image: radial-gradient(160% 120% at 10% 0%, rgba(34, 211, 238, 0.08), transparent 60%),
+      radial-gradient(120% 140% at 100% 10%, rgba(16, 185, 129, 0.18), transparent 55%),
+      radial-gradient(120% 120% at 40% 120%, rgba(59, 130, 246, 0.12), transparent 65%),
+      linear-gradient(180deg, rgba(2, 6, 23, 0.92), rgba(2, 6, 23, 0.96));
+    background-color: hsl(var(--background));
+  }
+}
+
+@keyframes pulse-glow {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 0.85;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,18 @@
 import type { Metadata } from "next";
-import { Open_Sans } from "next/font/google";
+import { IBM_Plex_Mono, Space_Grotesk } from "next/font/google";
 import { cn } from "@/lib/utils";
 import "./globals.css";
 
-const font = Open_Sans({ subsets: ["latin"] });
+const grotesk = Space_Grotesk({
+  subsets: ["latin"],
+  variable: "--font-grotesk",
+});
+
+const plexMono = IBM_Plex_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-plex",
+});
 
 export const metadata: Metadata = {
   title: "Alexander Fuerst - Fuerst.one Auto-CV",
@@ -19,8 +28,10 @@ export default function RootLayout({
     <html lang="en">
       <body
         className={cn(
-          "flex min-h-full flex-col bg-white text-black dark:bg-gray-950",
-          font.className,
+          "relative flex min-h-full flex-col bg-background text-foreground antialiased",
+          grotesk.className,
+          grotesk.variable,
+          plexMono.variable,
         )}
       >
         {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,31 +35,39 @@ export default async function Home({
   const featuredProjects = filteredProjects.slice(0, SLICE_DEFAULT);
   const otherProjects = filteredProjects.slice(SLICE_DEFAULT);
   const hasOtherProjects = otherProjects.length > 0;
+  const descriptor =
+    firstFilterApplied && firstFilterApplied !== "true"
+      ? firstFilterApplied
+      : "signature";
 
   return (
     <Layout sidebarContent={<Intro claim={getClaim(filterParams)} />}>
-      <div className="pl-2 pr-2 lg:pl-4 lg:pr-4">
-        <div className="mb-4">
-          <h2 className="text-2xl font-bold">
-            My {filteredProjects.length} most interesting
-            {firstFilterApplied ? ` "${firstFilterApplied}"` : ""} projects{" "}
-            sorted by most recent
+      <div className="pl-1 pr-1 lg:pl-4 lg:pr-4">
+        <div className="mb-12 space-y-5">
+          <span className="font-[var(--font-plex)] text-[0.65rem] uppercase tracking-[0.22em] text-emerald-300/80">
+            Project Index
+          </span>
+          <h2 className="text-3xl font-semibold text-white">
+            {filteredProjects.length} {descriptor} projects, handcrafted for momentum
           </h2>
+          <p className="max-w-2xl text-sm leading-relaxed text-slate-400">
+            Every entry is a blend of systems thinking and generative aesthetics,
+            surfaced by recency. Use the analysis tools to remix the view and dive
+            deeper into the collaborations, stacks, and outcomes that matter to you.
+          </p>
           {!hasFiltersApplied && (
-            <div className="my-4">
+            <div className="pt-2">
               <FiltersCollapse projects={projects} />
             </div>
           )}
-          <p className="text-sm">
-            {hasFiltersApplied && (
-              <Link
-                href="/"
-                className="text-blue-500 hover:underline print:hidden"
-              >
-                See all projects
-              </Link>
-            )}
-          </p>
+          {hasFiltersApplied && (
+            <Link
+              href="/"
+              className="inline-flex items-center gap-3 text-sm font-[var(--font-plex)] uppercase tracking-[0.18em] text-emerald-300 transition hover:text-white print:hidden"
+            >
+              Reset filters
+            </Link>
+          )}
         </div>
         <div className="space-y-8">
           {featuredProjects.map((project) => (

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -9,11 +9,12 @@ function ButtonInner({
   children: React.ReactNode;
 }) {
   return (
-    <>
-      <span className="absolute inset-0 rounded-md bg-gradient-to-b from-white/80 to-white opacity-10 transition-opacity group-hover:opacity-15" />
-      <span className="opacity-7.5 absolute inset-0 rounded-md transition-opacity group-hover:opacity-10" />
-      {children} {arrow ? <span aria-hidden="true">&rarr;</span> : null}
-    </>
+    <span className="relative flex items-center gap-3 px-5 py-2">
+      <span className="text-[0.7rem] font-semibold uppercase tracking-[0.24em]">
+        {children}
+      </span>
+      {arrow ? <span aria-hidden="true">↗</span> : null}
+    </span>
   );
 }
 
@@ -27,9 +28,8 @@ export function Button({
   | ({ href?: undefined } & React.ComponentPropsWithoutRef<"button">)
 )) {
   className = cn(
+    "inline-flex flex-none items-center justify-center overflow-hidden rounded-full bg-emerald-400/90 text-slate-950 shadow-[0_10px_30px_rgba(16,185,129,0.25)] transition hover:bg-emerald-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950",
     className,
-    "group relative isolate flex-none rounded-md py-1.5 text-[0.8125rem]/6 font-semibold text-white",
-    arrow ? "pl-2.5 pr-[calc(9/16*1rem)]" : "px-2.5",
   );
 
   return typeof props.href === "undefined" ? (

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -5,8 +5,12 @@ import { FaLinkedin } from "@react-icons/all-files/fa/FaLinkedin";
 
 export const Contact = () => {
   return (
-    <div className="mt-8 flex flex-wrap justify-center gap-x-1 gap-y-3 sm:gap-x-2 lg:justify-start print:block">
-      <IconLink href="https://fuerst.one" icon={FaMap} className="flex-none">
+    <div className="mt-8 flex flex-wrap justify-center gap-x-2 gap-y-3 lg:justify-start print:block">
+      <IconLink
+        href="https://fuerst.one"
+        icon={FaMap}
+        className="flex-none"
+      >
         Homepage
         <span className="hidden print:inline"> (https://fuerst.one)</span>
       </IconLink>

--- a/src/components/IconLink.tsx
+++ b/src/components/IconLink.tsx
@@ -16,13 +16,13 @@ export function IconLink({
       {...props}
       className={cn(
         className,
-        "hover:text-sky-30 group relative isolate flex items-center rounded-lg px-2 py-0.5 text-[0.8125rem]/6 font-medium text-black/30 transition-colors dark:text-white/30 dark:hover:text-sky-700",
-        compact ? "gap-x-2" : "gap-x-3",
+        "group relative isolate flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-[0.75rem] font-medium text-slate-200 transition hover:border-emerald-400/50 hover:text-white",
+        compact ? "px-3" : "px-4",
       )}
     >
-      <span className="absolute inset-0 -z-10 scale-75 rounded-lg bg-black/5 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 dark:bg-white/5" />
-      {Icon && <Icon className="h-4 w-4 flex-none" />}
-      <span className="self-baseline text-black dark:text-white">
+      <span className="absolute inset-0 -z-10 scale-95 rounded-full border border-white/10 bg-white/5 opacity-0 transition group-hover:scale-100 group-hover:opacity-100" />
+      {Icon && <Icon className="h-4 w-4 flex-none text-emerald-300" />}
+      <span className="self-baseline text-slate-100">
         {children}
       </span>
     </Link>

--- a/src/components/Intro.tsx
+++ b/src/components/Intro.tsx
@@ -6,35 +6,59 @@ import { Contact } from "./Contact";
 
 export function Intro({ claim }: { claim: ReactNode }) {
   return (
-    <>
-      <Image
-        src="/avatar.png"
-        alt="Alexander Fuerst"
-        width={80}
-        height={80}
-        className="h-20 w-20 print:mt-8"
-      />
-      <h1 className="font-display mt-6 text-4xl/tight text-black dark:text-white print:text-black">
-        <span className="font-black">Alexander Fuerst</span>
-        <br />
-        <span className="text-2xl font-light text-sky-300 dark:text-sky-300 print:text-black">
-          UI Engineer – CV & Portfolio
-        </span>
-      </h1>
-      <p className="mt-4 text-sm/6 text-gray-700 dark:text-gray-300 print:text-black">
-        {claim}
-      </p>
+    <div className="space-y-6">
+      <div className="flex items-start gap-4">
+        <div className="group relative h-20 w-20 overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-1">
+          <Image
+            src="/avatar.png"
+            alt="Alexander Fuerst"
+            width={80}
+            height={80}
+            className="h-full w-full rounded-[1.1rem] object-cover"
+          />
+          <div className="absolute inset-0 rounded-[1.1rem] border border-white/10 opacity-0 transition group-hover:opacity-100" />
+        </div>
+        <div className="flex-1 space-y-3">
+          <span className="inline-flex items-center gap-2 rounded-full border border-emerald-400/20 bg-emerald-500/10 px-3 py-1 text-[0.65rem] font-[var(--font-plex)] uppercase tracking-[0.24em] text-emerald-200">
+            <span className="h-1 w-1 rounded-full bg-emerald-400 animate-[pulse-glow_4s_ease-in-out_infinite]" />
+            Creative Technologist
+          </span>
+          <h1 className="text-4xl font-semibold leading-tight text-white">
+            Alexander Fuerst
+          </h1>
+          <p className="font-[var(--font-plex)] text-xs uppercase tracking-[0.2em] text-slate-400">
+            UI engineer · generative aesthetics · product craftsmanship
+          </p>
+        </div>
+      </div>
+      <div className="space-y-4 text-sm text-slate-300">
+        <p className="text-base leading-relaxed text-slate-200">{claim}</p>
+        <p className="font-[var(--font-plex)] text-xs uppercase tracking-[0.16em] text-slate-400">
+          Building immersive interfaces that fuse rigorous systems with playful art.
+        </p>
+      </div>
       <SignUpForm />
       <Contact />
-    </>
+    </div>
   );
 }
 
 export function IntroFooter() {
   return (
-    <p className="flex items-baseline gap-x-2 text-[0.8125rem]/6 text-gray-500 print:hidden">
-      <Link href="https://fuerst.one/imprint">Imprint</Link>|
-      <Link href="https://fuerst.one/privacy-policy">Privacy Policy</Link>
+    <p className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[0.75rem] text-slate-500 print:hidden">
+      <Link
+        className="transition hover:text-emerald-300"
+        href="https://fuerst.one/imprint"
+      >
+        Imprint
+      </Link>
+      <span className="opacity-40">/</span>
+      <Link
+        className="transition hover:text-emerald-300"
+        href="https://fuerst.one/privacy-policy"
+      >
+        Privacy Policy
+      </Link>
     </p>
   );
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,123 +1,62 @@
-import { ReactNode, Suspense, useId } from "react";
+import { ReactNode, Suspense } from "react";
 
 import { IntroFooter } from "./Intro";
-import { StarField } from "./StarField";
-
-function Timeline() {
-  const id = useId();
-
-  return (
-    <div className="pointer-events-none absolute inset-0 z-50 hidden overflow-hidden lg:right-[calc(max(2rem,50%-38rem)+40rem)] lg:block lg:min-w-[32rem] lg:overflow-visible print:hidden">
-      <svg
-        className="absolute left-[max(0px,calc(50%-18.125rem))] top-0 h-full w-1.5 lg:left-full lg:ml-1 xl:left-auto xl:right-1 xl:ml-0"
-        aria-hidden="true"
-      >
-        <defs>
-          <pattern id={id} width="6" height="8" patternUnits="userSpaceOnUse">
-            <path
-              d="M0 0H6M0 8H6"
-              className="stroke-sky-900/10 dark:stroke-white/10 xl:stroke-white/10"
-              fill="none"
-            />
-          </pattern>
-        </defs>
-        <rect width="100%" height="100%" fill={`url(#${id})`} />
-      </svg>
-    </div>
-  );
-}
-
-function Glow() {
-  const id = useId();
-
-  return (
-    <div className="absolute inset-0 -z-10 overflow-hidden bg-gray-950 lg:right-[calc(max(2rem,50%-38rem)+40rem)] lg:min-w-[32rem] print:hidden">
-      <svg
-        className="absolute -bottom-48 left-[-40%] h-[80rem] w-[180%] lg:-right-40 lg:bottom-auto lg:left-auto lg:top-[-40%] lg:h-[180%] lg:w-[80rem] print:w-auto"
-        aria-hidden="true"
-      >
-        <defs>
-          <radialGradient id={`${id}-desktop`} cx="100%">
-            <stop offset="0%" stopColor="rgba(56, 189, 248, 0.3)" />
-            <stop offset="53.95%" stopColor="rgba(0, 71, 255, 0.09)" />
-            <stop offset="100%" stopColor="rgba(10, 14, 23, 0)" />
-          </radialGradient>
-          <radialGradient id={`${id}-mobile`} cy="100%">
-            <stop offset="0%" stopColor="rgba(56, 189, 248, 0.3)" />
-            <stop offset="53.95%" stopColor="rgba(0, 71, 255, 0.09)" />
-            <stop offset="100%" stopColor="rgba(10, 14, 23, 0)" />
-          </radialGradient>
-        </defs>
-        <rect
-          width="100%"
-          height="100%"
-          fill={`url(#${id}-desktop)`}
-          className="hidden lg:block"
-        />
-        <rect
-          width="100%"
-          height="100%"
-          fill={`url(#${id}-mobile)`}
-          className="lg:hidden"
-        />
-      </svg>
-      <div className="absolute inset-x-0 bottom-0 right-0 h-px bg-white mix-blend-overlay lg:left-auto lg:top-0 lg:h-auto lg:w-px" />
-    </div>
-  );
-}
-
-function FixedSidebar({
-  background,
-  children,
-}: {
-  background: ReactNode;
-  children: ReactNode;
-}) {
-  return (
-    <div className="dark relative flex-none overflow-hidden px-6 lg:pointer-events-none lg:fixed lg:inset-0 lg:z-40 lg:flex lg:px-0">
-      <Glow />
-      <div className="relative flex w-full lg:pointer-events-auto lg:mr-[calc(max(2rem,50%-38rem)+40rem)] lg:min-w-[32rem] lg:overflow-y-auto lg:overflow-x-hidden lg:pl-[max(4rem,calc(50%-38rem))]">
-        {background}
-        <div className="z-10 mx-auto max-w-lg lg:mx-0 lg:flex lg:w-96 lg:max-w-none lg:flex-col lg:before:flex-1 lg:before:pt-6">
-          <div className="pb-16 pt-20 sm:pb-20 sm:pt-32 lg:py-20 print:py-0">
-            <div className="relative">
-              <StarField className="-right-44 top-14" />
-              {children}
-            </div>
-          </div>
-          <div className="flex flex-1 items-end justify-center pb-4 lg:justify-start lg:pb-6">
-            <IntroFooter />
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 export function Layout({
   sidebarContent,
-  sidebarBackground,
   children,
 }: {
   sidebarContent: ReactNode;
-  sidebarBackground?: ReactNode;
   children: ReactNode;
 }) {
   return (
-    <>
-      <FixedSidebar background={sidebarBackground}>
-        {sidebarContent}
-      </FixedSidebar>
-      <div className="relative flex-auto">
-        <Timeline />
-        <main className="mx-auto max-w-7xl space-y-20 px-6 py-20 sm:space-y-32 lg:flex lg:px-8">
-          <div className="lg:ml-96 lg:flex lg:w-full lg:justify-end lg:pl-32">
-            <div className="mx-auto max-w-lg lg:mx-0 lg:w-0 lg:max-w-xl lg:flex-auto">
-              <Suspense>{children}</Suspense>
+    <div className="relative min-h-screen overflow-hidden">
+      <div aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -left-32 top-[-20%] h-[28rem] w-[28rem] rounded-full bg-[radial-gradient(circle,rgba(16,185,129,0.16),transparent_65%)] blur-3xl" />
+        <div className="absolute right-[-12%] top-1/3 h-[34rem] w-[34rem] rounded-full bg-[radial-gradient(circle,rgba(56,189,248,0.18),transparent_60%)] blur-3xl" />
+        <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(7,11,19,0.65),rgba(7,11,19,0.92))]" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(148,163,184,0.12),transparent_75%)]" />
+      </div>
+
+      <div className="relative z-10 mx-auto flex w-full max-w-6xl flex-col gap-16 px-6 py-12 sm:px-8 lg:px-12">
+        <header className="flex flex-col gap-6 text-sm text-slate-400">
+          <div className="flex flex-wrap items-center justify-between gap-6">
+            <div className="flex flex-col gap-2">
+              <span className="font-[var(--font-plex)] text-[0.65rem] uppercase tracking-[0.22em] text-emerald-300/80">
+                fuerst.one
+              </span>
+              <div className="flex flex-col gap-1 text-slate-200">
+                <span className="text-2xl font-semibold text-white">Alexander Fuerst</span>
+                <span className="font-[var(--font-plex)] text-xs uppercase tracking-[0.2em] text-slate-400">
+                  UI engineer · generative aesthetics · product craftsmanship
+                </span>
+              </div>
+            </div>
+            <div className="flex items-center gap-4 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-[0.7rem] font-[var(--font-plex)] uppercase tracking-[0.18em] text-slate-300">
+              <span className="inline-flex h-1.5 w-1.5 rounded-full bg-emerald-400" />
+              Creative Technologist
             </div>
           </div>
-        </main>
+          <div className="h-px w-full bg-gradient-to-r from-transparent via-emerald-400/50 to-transparent" />
+        </header>
+
+        <div className="grid items-start gap-12 lg:grid-cols-[360px,1fr] lg:gap-16">
+          <aside className="lg:sticky lg:top-24">
+            <div className="relative space-y-10 overflow-hidden rounded-[2rem] border border-white/10 bg-white/5 p-8 shadow-[0_25px_60px_rgba(8,11,19,0.55)] backdrop-blur-xl">
+              <div className="pointer-events-none absolute inset-x-6 top-0 h-px bg-gradient-to-r from-transparent via-emerald-400/50 to-transparent" />
+              {sidebarContent}
+              <div className="border-t border-white/10 pt-6 text-xs text-slate-500">
+                <IntroFooter />
+              </div>
+            </div>
+          </aside>
+          <main className="flex-1 pb-24">
+            <div className="mx-auto w-full max-w-3xl space-y-12">
+              <Suspense>{children}</Suspense>
+            </div>
+          </main>
+        </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/components/Projects/Filter/FiltersCollapse.tsx
+++ b/src/components/Projects/Filter/FiltersCollapse.tsx
@@ -14,7 +14,8 @@ export const FiltersCollapse = ({ projects }: { projects: CvProject[] }) => {
   return (
     <div>
       <button
-        className="mb-4 w-full rounded border px-2 py-1 text-center hover:bg-gray-100 print:hidden"
+        type="button"
+        className="mb-6 w-full rounded-full border border-white/10 bg-white/5 px-4 py-3 text-center text-sm font-[var(--font-plex)] uppercase tracking-[0.2em] text-slate-200 transition hover:border-emerald-400/50 hover:text-white print:hidden"
         onClick={() => setIsCollapsed(!isCollapsed)}
       >
         {isCollapsed ? "Show" : "Hide"} analysis and filters
@@ -22,11 +23,11 @@ export const FiltersCollapse = ({ projects }: { projects: CvProject[] }) => {
       {!isCollapsed ? (
         <>
           <h2 className="hidden">Overview of my work experience</h2>
-          <p className="mb-2 text-gray-500">
+          <p className="mb-4 font-[var(--font-plex)] text-xs uppercase tracking-[0.16em] text-slate-400">
             Try clicking on something below to filter
           </p>
           <ProjectFilters projects={projects} />
-          <hr className="my-8" />
+          <hr className="my-10 border-white/10" />
         </>
       ) : null}
     </div>

--- a/src/components/Projects/Filter/ProjectFilters.tsx
+++ b/src/components/Projects/Filter/ProjectFilters.tsx
@@ -8,10 +8,15 @@ import { filterConfigs } from "../filterConfigs";
 
 export const ProjectFilters = ({ projects }: { projects: CvProject[] }) => {
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+    <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
       {filterConfigs.map((filterConfig) => (
-        <div key={filterConfig.projectKey} className="rounded-lg border p-2">
-          <h2 className="text-md mb-2 font-bold">{filterConfig.label}</h2>
+        <div
+          key={filterConfig.projectKey}
+          className="rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur"
+        >
+          <h2 className="text-md mb-4 font-[var(--font-plex)] text-xs uppercase tracking-[0.18em] text-slate-300">
+            {filterConfig.label}
+          </h2>
           <Filter filterConfig={filterConfig} projects={projects} />
         </div>
       ))}

--- a/src/components/Projects/ProjectCard.tsx
+++ b/src/components/Projects/ProjectCard.tsx
@@ -28,63 +28,78 @@ export const ProjectCard = ({
   const description = getJsxFormattedTextFromTextBlock(project.description);
   const kpis = getJsxFormattedTextFromTextBlock(project.kpis);
 
-  const { border, text } = colors.projectType![projectType] ?? {};
+  const { text } = colors.projectType![projectType] ?? {};
 
   return (
-    <article className={cn("space-y-2 border-l-2 px-6 py-3", border)}>
-      <div className="flex items-center justify-between">
-        <header>
-          <h3 className="text-md font-bold leading-tight">
-            {name}{" "}
-            <span className={cn("font-medium", text)}>({projectType})</span>
-          </h3>
-          <div className="text-sm text-gray-600">
-            <DateRange startDate={startDate} endDate={endDate} />
+    <article
+      className={cn(
+        "group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_18px_40px_rgba(8,11,19,0.45)] backdrop-blur transition",
+        "hover:border-emerald-400/50 hover:bg-white/10",
+      )}
+    >
+      <div className="relative flex items-start justify-between gap-4">
+        <header className="space-y-3">
+          <div className="space-y-1">
+            <span className={cn("inline-flex items-center gap-2 font-[var(--font-plex)] text-[0.65rem] uppercase tracking-[0.2em] text-slate-400", text)}>
+              <span className="h-1 w-1 rounded-full bg-emerald-400" />
+              {projectType}
+            </span>
+            <h3 className="text-2xl font-semibold text-white">{name}</h3>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-slate-400">
+            <span className="font-[var(--font-plex)] tracking-[0.12em]">
+              <DateRange startDate={startDate} endDate={endDate} />
+            </span>
             {websiteUrl && (
               <Link
                 href={websiteUrl}
                 target="_blank"
-                className="ml-1 inline-flex items-center gap-1 rounded-sm bg-gray-100 px-1 text-xs font-medium print:ml-0 print:block print:px-0"
+                className="inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 text-[0.65rem] font-[var(--font-plex)] uppercase tracking-[0.18em] text-slate-200 transition hover:border-emerald-400/50 hover:text-white print:ml-0 print:block"
               >
-                Website<span className="hidden print:inline">: </span>
-                <FaExternalLinkAlt className="print:hidden" />
-                <span className="hidden print:inline">{websiteUrl}</span>
+                Website
+                <FaExternalLinkAlt className="text-xs print:hidden" />
+                <span className="hidden print:inline">: {websiteUrl}</span>
               </Link>
             )}
             {githubUrl && (
               <Link
                 href={githubUrl}
                 target="_blank"
-                className="ml-1 inline-flex items-center gap-1 rounded-sm bg-gray-100 px-1 text-xs font-medium print:ml-0 print:block print:px-0"
+                className="inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 text-[0.65rem] font-[var(--font-plex)] uppercase tracking-[0.18em] text-slate-200 transition hover:border-emerald-400/50 hover:text-white print:ml-0 print:block"
               >
-                Github<span className="hidden print:inline">: </span>
-                <FaGithub className="print:hidden" />
-                <span className="hidden print:inline">{githubUrl}</span>
+                GitHub
+                <FaGithub className="text-xs print:hidden" />
+                <span className="hidden print:inline">: {githubUrl}</span>
               </Link>
             )}
           </div>
         </header>
-        <div className="hidden sm:block lg:hidden 2xl:block print:hidden">
+        <div className="hidden shrink-0 items-center justify-center rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-slate-200 shadow-inner sm:flex lg:hidden 2xl:flex print:hidden">
           {logo ? (
-            <div className="h-6 w-auto">
+            <div className="h-8 w-20">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={logo?.[0]}
                 alt={name}
-                className="h-full w-full object-cover"
+                className="h-full w-full object-contain"
               />
             </div>
           ) : (
-            <FaImage className="text-xl text-gray-400" />
+            <FaImage className="text-xl" />
           )}
         </div>
       </div>
       {kpis && (
-        <div className="text-xs text-green-700">
-          <FaChartLine className="inline" /> {kpis}
+        <div className="relative mt-4 flex items-center gap-2 text-sm text-emerald-300">
+          <FaChartLine className="text-base" />
+          <span>{kpis}</span>
         </div>
       )}
-      {description && <div className="text-xs">{description}</div>}
+      {description && (
+        <div className="mt-4 space-y-2 text-sm leading-relaxed text-slate-200">
+          {description}
+        </div>
+      )}
       {!compact && <MetaTable project={project} />}
     </article>
   );
@@ -109,14 +124,14 @@ const DateRange = ({
   if (startDateFormatted === endDateFormatted) {
     return (
       <span>
-        {startDateFormatted} ({duration})
+        {startDateFormatted} · {duration}
       </span>
     );
   }
 
   return (
     <span>
-      {startDateFormatted} - {endDateFormatted} ({duration})
+      {startDateFormatted} – {endDateFormatted} · {duration}
     </span>
   );
 };
@@ -145,13 +160,15 @@ const MetaTable = ({ project }: { project: CvProject }) => {
     }));
 
   return (
-    <div className="flex flex-col">
+    <div className="mt-6 space-y-3 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-200">
       {filteredFields.map(({ label, projectKey, value }) => (
         <div
           key={projectKey}
-          className="-mx-1 flex items-center justify-start gap-1 rounded-sm px-2 py-1 text-xs leading-tight odd:bg-gray-100"
+          className="flex flex-col gap-1 rounded-xl border border-white/10 bg-slate-900/40 p-3 sm:flex-row sm:items-baseline sm:gap-4"
         >
-          <h3 className="w-[150px] shrink-0">{label}</h3>
+          <h3 className="w-36 shrink-0 font-[var(--font-plex)] text-[0.7rem] uppercase tracking-[0.2em] text-slate-400">
+            {label}
+          </h3>
           <Property projectKey={projectKey} value={value} />
         </div>
       ))}
@@ -168,7 +185,7 @@ const Property = <TKey extends keyof CvProject>({
 }) => {
   if (projectKey === "clients") {
     return (
-      <div className="flex flex-wrap gap-1">
+      <div className="flex flex-wrap gap-2">
         {(value as { id: string; name: string }[]).map((item) => (
           <Tag key={item.id} className="flex gap-0.5">
             <div>{item.name}</div>
@@ -179,7 +196,7 @@ const Property = <TKey extends keyof CvProject>({
   }
   if (Array.isArray(value)) {
     return (
-      <div className="flex flex-wrap gap-1">
+      <div className="flex flex-wrap gap-2">
         {(value as string[]).map((i, idx) => (
           <Tag key={idx} searchParamKey={projectKey} value={i}>
             {i}
@@ -188,5 +205,5 @@ const Property = <TKey extends keyof CvProject>({
       </div>
     );
   }
-  return value as string;
+  return <span className="text-slate-200">{value as string}</span>;
 };

--- a/src/components/Projects/ProjectCollapse.tsx
+++ b/src/components/Projects/ProjectCollapse.tsx
@@ -9,7 +9,7 @@ export const ProjectCollapse = ({ children }: { children: ReactNode }) => {
     return (
       <div>
         <button
-          className="w-full rounded border px-2 py-1 text-center hover:bg-gray-100 print:hidden"
+          className="w-full rounded-full border border-white/10 bg-white/5 px-4 py-3 text-center text-sm font-[var(--font-plex)] uppercase tracking-[0.2em] text-slate-200 transition hover:border-emerald-400/50 hover:text-white print:hidden"
           onClick={() => setIsCollapsed(false)}
         >
           Show more projects

--- a/src/components/Projects/Tag.tsx
+++ b/src/components/Projects/Tag.tsx
@@ -21,8 +21,11 @@ export const Tag = ({
   return (
     <span
       className={cn(
-        "rounded-sm border border-gray-300 px-1 py-0.5",
-        { "cursor-pointer hover:bg-gray-200": hasSearchParam },
+        "inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[0.65rem] font-[var(--font-plex)] uppercase tracking-[0.18em] text-slate-200 transition",
+        {
+          "cursor-pointer border-emerald-400/40 text-emerald-200 hover:border-emerald-300/60 hover:text-white":
+            hasSearchParam,
+        },
         className,
       )}
       onClick={() => toggleSearchParam(searchParamKey, value)}

--- a/src/components/SignUpForm.tsx
+++ b/src/components/SignUpForm.tsx
@@ -34,7 +34,7 @@ export function SignUpForm() {
   return (
     <form
       onSubmit={handleSubmit}
-      className="relative isolate mt-8 flex items-center pr-1 print:hidden"
+      className="relative isolate mt-8 flex items-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 print:hidden backdrop-blur"
     >
       <label htmlFor={id} className="sr-only">
         Email address
@@ -46,13 +46,13 @@ export function SignUpForm() {
         name="email"
         id={id}
         placeholder="Email address"
-        className="peer w-0 flex-auto bg-transparent px-4 py-2.5 text-base text-white placeholder:text-gray-500 focus:outline-none sm:text-[0.8125rem]/6"
+        className="peer w-0 flex-auto bg-transparent px-2 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none"
       />
       <Button type="submit" arrow={!isLoading}>
         {isLoading ? <FaHourglass className="inline" /> : "Get PDF CV"}
       </Button>
-      <div className="absolute inset-0 -z-10 rounded-lg transition peer-focus:ring-4 peer-focus:ring-sky-300/15" />
-      <div className="bg-white/2.5 absolute inset-0 -z-10 rounded-lg ring-1 ring-white/15 transition peer-focus:ring-sky-300" />
+      <div className="pointer-events-none absolute inset-0 -z-10 rounded-2xl border border-white/10 transition peer-focus-within:border-emerald-400/60" />
+      <div className="pointer-events-none absolute inset-0 -z-20 rounded-2xl bg-gradient-to-r from-emerald-500/10 via-transparent to-sky-500/10 opacity-0 transition peer-focus-within:opacity-100" />
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- reduce monospace tracking across hero, layout, and project surfaces for cleaner readability
- lighten project cards, tags, and reset link spacing to keep the futuristic look legible
- ensure the filters collapse toggle is a button element so the filter analysis panel opens again

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dbc2c6db1c832d9da92dc7a14a342c