### PR TITLE
Fix FiltersCollapse crash with empty bar chart data

### DIFF
--- a/src/components/Projects/Filter/BarChartFilter.tsx
+++ b/src/components/Projects/Filter/BarChartFilter.tsx
@@ -15,7 +15,15 @@ export const BarChartFilter = ({
 }) => {
   const { projectKey } = filterConfig;
   const itemCounts = getFilterOptionCounts(projects, projectKey);
-  const maxCount = maxBy(itemCounts, "count")!.count;
+  const maxCount = maxBy(itemCounts, "count")?.count ?? 0;
+
+  if (!itemCounts.length || maxCount === 0) {
+    return (
+      <div className="flex h-[215px] w-full items-center justify-center text-xs text-slate-500">
+        No data available yet
+      </div>
+    );
+  }
 
   return (
     <div className="h-[215px] w-full overflow-y-scroll pr-1">


### PR DESCRIPTION
## Summary
- guard the bar chart filter against empty datasets so toggling the filters panel no longer crashes
- render a friendly fallback message when a filter has no data to display

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dbd5683614832db06e2c2b54ee776d