### PR TITLE
Restore project logos with marquee banner

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { Layout } from "@/components/Layout";
 import { ProjectCard } from "@/components/Projects/ProjectCard";
+import { LogoMarquee } from "@/components/Projects/LogoMarquee";
+import { getProjectLogoSources } from "@/components/Projects/getProjectLogoSources";
 import { getCvProjects } from "@/server/notion/getCvProjects";
 import {
   filterProjects,
@@ -45,6 +47,18 @@ export default async function Home({
       ? firstFilterApplied
       : "signature";
 
+  const marqueeLogos = projects
+    .flatMap((project) =>
+      getProjectLogoSources(project).map((src) => ({
+        src,
+        alt: `${project.name} logo`,
+      })),
+    )
+    .filter(
+      (logo, index, array) =>
+        array.findIndex((candidate) => candidate.src === logo.src) === index,
+    );
+
   return (
     <Layout
       sidebarContent={
@@ -52,6 +66,9 @@ export default async function Home({
           <Intro claim={getClaim(filterParams)} />
           <ProjectAnalysisPanel projects={projects} />
         </>
+      }
+      topContent={
+        marqueeLogos.length > 0 ? <LogoMarquee logos={marqueeLogos} /> : null
       }
     >
       <div className="pl-1 pr-1 lg:pl-4 lg:pr-4">

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,9 +4,11 @@ import { IntroFooter } from "./Intro";
 
 export function Layout({
   sidebarContent,
+  topContent,
   children,
 }: {
   sidebarContent: ReactNode;
+  topContent?: ReactNode;
   children: ReactNode;
 }) {
   return (
@@ -57,6 +59,8 @@ export function Layout({
           </div>
           <div className="h-px w-full bg-gradient-to-r from-transparent via-emerald-400/50 to-transparent" />
         </header>
+
+        {topContent}
 
         <div className="grid items-start gap-12 lg:grid-cols-[360px,1fr] lg:gap-16">
           <aside className="lg:sticky lg:top-24">

--- a/src/components/PDF/ProjectCard.tsx
+++ b/src/components/PDF/ProjectCard.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 import { CvProject } from "@/server/notion/getCvProjects";
+import { getProjectLogoSources } from "../Projects/getProjectLogoSources";
 import { Slideshow } from "./Slideshow";
 import { FormattedDate } from "../FormattedDate";
 import { getJsxFormattedTextFromTextBlock } from "../Projects/getJsxFormattedTextFromTextBlock";
@@ -8,7 +9,6 @@ import { Badge } from "../ui/badge";
 export const ProjectCard = ({ project }: { project: CvProject }) => {
   const {
     name,
-    logo,
     websiteUrl,
     githubUrl,
     startDate,
@@ -16,6 +16,8 @@ export const ProjectCard = ({ project }: { project: CvProject }) => {
     clients,
     screenshots,
   } = project;
+  const logos = getProjectLogoSources(project);
+  const primaryLogo = logos[0];
 
   return (
     <div key={project.id} className="rounded-lg border p-4">
@@ -23,9 +25,9 @@ export const ProjectCard = ({ project }: { project: CvProject }) => {
         <h3 className="text-xl font-semibold text-gray-800 dark:text-gray-200">
           {name}
         </h3>
-        {!!logo?.length && (
+        {primaryLogo && (
           <img
-            src={logo[0] || "/logo.svg"}
+            src={primaryLogo}
             alt={`${name} logo`}
             className="h-full w-auto object-contain"
           />

--- a/src/components/Projects/LogoMarquee.tsx
+++ b/src/components/Projects/LogoMarquee.tsx
@@ -1,0 +1,62 @@
+type LogoMarqueeProps = {
+  logos: { src: string; alt: string }[];
+};
+
+const getUniqueLogos = (logos: LogoMarqueeProps["logos"]) => {
+  const seen = new Set<string>();
+
+  return logos.filter(({ src }) => {
+    if (seen.has(src)) {
+      return false;
+    }
+
+    seen.add(src);
+    return true;
+  });
+};
+
+export const LogoMarquee = ({ logos }: LogoMarqueeProps) => {
+  const uniqueLogos = getUniqueLogos(logos);
+
+  if (uniqueLogos.length === 0) {
+    return null;
+  }
+
+  const marqueeItems = [...uniqueLogos, ...uniqueLogos];
+  const animationDurationSeconds = Math.max(uniqueLogos.length * 4, 24);
+
+  return (
+    <div className="relative overflow-hidden rounded-full border border-white/10 bg-white/5 px-8">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-y-0 left-0 w-16 bg-gradient-to-r from-slate-900 via-slate-900/80 to-transparent"
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-slate-900 via-slate-900/80 to-transparent"
+      />
+      <div
+        className="flex w-max items-center gap-12 py-3 motion-safe:animate-marquee"
+        style={{
+          animationDuration: `${animationDurationSeconds}s`,
+        }}
+      >
+        {marqueeItems.map((logo, index) => (
+          <span
+            key={`${logo.src}-${index}`}
+            className="flex h-10 items-center"
+            aria-label={logo.alt}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={logo.src}
+              alt={logo.alt}
+              className="h-full w-auto max-w-[9rem] object-contain opacity-80 grayscale"
+              loading="lazy"
+            />
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/Projects/ProjectCard.tsx
+++ b/src/components/Projects/ProjectCard.tsx
@@ -12,6 +12,7 @@ import { FaChartLine } from "@react-icons/all-files/fa/FaChartLine";
 import { FaGithub } from "@react-icons/all-files/fa/FaGithub";
 import { cn } from "@/lib/utils";
 import { ProjectScreenshots } from "./ProjectScreenshots";
+import { getProjectLogoSources } from "./getProjectLogoSources";
 
 dayjs.extend(duration);
 dayjs.extend(relativeTime);
@@ -24,7 +25,6 @@ export const ProjectCard = ({ project }: { project: CvProject }) => {
     githubUrl,
     startDate,
     endDate,
-    logo,
     screenshots,
   } = project;
 
@@ -32,6 +32,8 @@ export const ProjectCard = ({ project }: { project: CvProject }) => {
   const kpis = getJsxFormattedTextFromTextBlock(project.kpis);
 
   const { text } = colors.projectType![projectType] ?? {};
+  const logos = getProjectLogoSources(project);
+  const primaryLogo = logos[0];
 
   return (
     <article
@@ -82,14 +84,15 @@ export const ProjectCard = ({ project }: { project: CvProject }) => {
             )}
           </div>
         </header>
-        <div className="hidden shrink-0 items-center justify-center rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-slate-200 shadow-inner sm:flex lg:hidden 2xl:flex print:hidden">
-          {logo ? (
-            <div className="h-8 w-20">
+        <div className="flex shrink-0 items-center justify-center rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-slate-200 shadow-inner print:hidden">
+          {primaryLogo ? (
+            <div className="h-6">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
-                src={logo?.[0]}
-                alt={name}
-                className="h-full w-full object-contain"
+                src={primaryLogo}
+                alt={`${name} logo`}
+                className="h-full w-auto object-contain"
+                loading="lazy"
               />
             </div>
           ) : (

--- a/src/components/Projects/getProjectLogoSources.ts
+++ b/src/components/Projects/getProjectLogoSources.ts
@@ -1,0 +1,35 @@
+import { CvProject } from "@/server/notion/getCvProjects";
+
+const getFallbackLogoFromUrl = (url: string | null): string | null => {
+  if (!url) {
+    return null;
+  }
+
+  try {
+    const hostname = new URL(url).hostname.replace(/^www\./, "");
+
+    if (!hostname) {
+      return null;
+    }
+
+    return `https://logo.clearbit.com/${hostname}`;
+  } catch {
+    return null;
+  }
+};
+
+export const getProjectLogoSources = (project: CvProject): string[] => {
+  const explicitLogos = (project.logo ?? []).filter(Boolean);
+
+  const uniqueLogos = Array.from(new Set(explicitLogos));
+
+  if (uniqueLogos.length > 0) {
+    return uniqueLogos;
+  }
+
+  const fallback =
+    getFallbackLogoFromUrl(project.websiteUrl) ??
+    getFallbackLogoFromUrl(project.githubUrl);
+
+  return fallback ? [fallback] : [];
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -67,10 +67,15 @@ const config = {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        marquee: {
+          from: { transform: "translateX(0)" },
+          to: { transform: "translateX(-50%)" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        marquee: "marquee var(--marquee-duration,30s) linear infinite",
       },
     },
   },


### PR DESCRIPTION
## Summary
- restore project brand logos in cards and PDF output using a shared helper with Clearbit fallbacks and consistent sizing
- add a marquee banner of grayscale brand logos to the layout header to surface partner brands
- extend Tailwind with marquee animation utilities to support the new banner

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dbff6b1930832d9dd721dab2a04811