### PR TITLE
Landing plasma: edge blur + synced anaglyph glitch

### DIFF
--- a/src/components/Plasma/GL/PlasmaCanvasGL.tsx
+++ b/src/components/Plasma/GL/PlasmaCanvasGL.tsx
@@ -20,7 +20,6 @@ import {
   PLASMA_GLITCH_TEAR_PX,
   PLASMA_GLITCH_DURATION,
   PLASMA_GLITCH_INTERVAL,
-  PLASMA_GLITCH_SHIFT,
   CENTER_YS,
   PLASMA_COMPLEXITY,
   PLASMA_LENS_BASE_RADIUS_FRAC,
@@ -241,7 +240,6 @@ const setupGL = (canvas: HTMLCanvasElement): GLState | null => {
     u_blurOuter: gl.getUniformLocation(postProgram, "u_blurOuter"),
     u_glitchInterval: gl.getUniformLocation(postProgram, "u_glitchInterval"),
     u_glitchDuration: gl.getUniformLocation(postProgram, "u_glitchDuration"),
-    u_glitchShift: gl.getUniformLocation(postProgram, "u_glitchShift"),
     u_glitchBands: gl.getUniformLocation(postProgram, "u_glitchBands"),
     u_glitchTearPx: gl.getUniformLocation(postProgram, "u_glitchTearPx"),
   };
@@ -251,7 +249,6 @@ const setupGL = (canvas: HTMLCanvasElement): GLState | null => {
   gl.uniform1f(postUniforms.u_blurOuter, PLASMA_BLUR_OUTER_FRAC);
   gl.uniform1f(postUniforms.u_glitchInterval, PLASMA_GLITCH_INTERVAL);
   gl.uniform1f(postUniforms.u_glitchDuration, PLASMA_GLITCH_DURATION);
-  gl.uniform1f(postUniforms.u_glitchShift, PLASMA_GLITCH_SHIFT);
   gl.uniform1f(postUniforms.u_glitchBands, PLASMA_GLITCH_BANDS);
   gl.useProgram(program);
 

--- a/src/components/Plasma/GL/PlasmaCanvasGL.tsx
+++ b/src/components/Plasma/GL/PlasmaCanvasGL.tsx
@@ -16,7 +16,7 @@ import {
   PLASMA_BLUR_INNER_FRAC,
   PLASMA_BLUR_MAX_PX,
   PLASMA_BLUR_OUTER_FRAC,
-  PLASMA_GLITCH_CA_PX,
+  PLASMA_GLITCH_TEAR_PX,
   PLASMA_GLITCH_DURATION,
   PLASMA_GLITCH_INTERVAL,
   PLASMA_GLITCH_SHIFT,
@@ -241,7 +241,7 @@ const setupGL = (canvas: HTMLCanvasElement): GLState | null => {
     u_glitchInterval: gl.getUniformLocation(postProgram, "u_glitchInterval"),
     u_glitchDuration: gl.getUniformLocation(postProgram, "u_glitchDuration"),
     u_glitchShift: gl.getUniformLocation(postProgram, "u_glitchShift"),
-    u_glitchCaPx: gl.getUniformLocation(postProgram, "u_glitchCaPx"),
+    u_glitchTearPx: gl.getUniformLocation(postProgram, "u_glitchTearPx"),
   };
   gl.useProgram(postProgram);
   gl.uniform1i(postUniforms.u_scene, 3);
@@ -500,7 +500,7 @@ const bindAndDraw = (
     (performance.now() - state.timeOrigin) / 1000,
   );
   gl.uniform1f(postUniforms.u_blurMaxPx, PLASMA_BLUR_MAX_PX * dpr);
-  gl.uniform1f(postUniforms.u_glitchCaPx, PLASMA_GLITCH_CA_PX * dpr);
+  gl.uniform1f(postUniforms.u_glitchTearPx, PLASMA_GLITCH_TEAR_PX * dpr);
   gl.viewport(0, 0, targetW, targetH);
   gl.bindVertexArray(state.postVao);
   gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);

--- a/src/components/Plasma/GL/PlasmaCanvasGL.tsx
+++ b/src/components/Plasma/GL/PlasmaCanvasGL.tsx
@@ -13,6 +13,13 @@ import {
   ANGLE_INCREMENTS,
   BASE_CHARACTERS,
   CENTER_XS,
+  PLASMA_BLUR_INNER_FRAC,
+  PLASMA_BLUR_MAX_PX,
+  PLASMA_BLUR_OUTER_FRAC,
+  PLASMA_GLITCH_CA_PX,
+  PLASMA_GLITCH_DURATION,
+  PLASMA_GLITCH_INTERVAL,
+  PLASMA_GLITCH_SHIFT,
   CENTER_YS,
   PLASMA_COMPLEXITY,
   PLASMA_LENS_BASE_RADIUS_FRAC,
@@ -32,7 +39,12 @@ import {
 } from "../constants";
 import { buildGlyphAtlas, GlyphAtlas, SDF_PARAMS } from "./buildGlyphAtlas";
 import { buildRampTable, packRampToRGBA } from "./buildRampTable";
-import { FRAGMENT_SHADER, VERTEX_SHADER } from "./shaders";
+import {
+  FRAGMENT_SHADER,
+  POST_FRAGMENT_SHADER,
+  POST_VERTEX_SHADER,
+  VERTEX_SHADER,
+} from "./shaders";
 
 export type PlasmaCanvasGLHandle = {
   renderPlasma: () => void;
@@ -87,9 +99,13 @@ const compileShader = (
   return shader;
 };
 
-const createProgram = (gl: WebGL2RenderingContext): WebGLProgram => {
-  const vs = compileShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER);
-  const fs = compileShader(gl, gl.FRAGMENT_SHADER, FRAGMENT_SHADER);
+const createProgram = (
+  gl: WebGL2RenderingContext,
+  vertexSource: string,
+  fragmentSource: string,
+): WebGLProgram => {
+  const vs = compileShader(gl, gl.VERTEX_SHADER, vertexSource);
+  const fs = compileShader(gl, gl.FRAGMENT_SHADER, fragmentSource);
   const program = gl.createProgram();
   if (!program) throw new Error("createProgram failed");
   gl.attachShader(program, vs);
@@ -151,6 +167,13 @@ type GLState = {
   luminanceTex: WebGLTexture;
   atlas: GlyphAtlas;
   uniforms: Record<string, WebGLUniformLocation | null>;
+  postProgram: WebGLProgram;
+  postVao: WebGLVertexArrayObject;
+  postUniforms: Record<string, WebGLUniformLocation | null>;
+  sceneTex: WebGLTexture;
+  sceneFbo: WebGLFramebuffer;
+  sceneSize: { width: number; height: number };
+  timeOrigin: number;
   rampLength: number;
   lastRampSignature: string;
   lastLuminanceSize: { width: number; height: number };
@@ -171,7 +194,7 @@ const setupGL = (canvas: HTMLCanvasElement): GLState | null => {
   });
   if (!gl) return null;
 
-  const program = createProgram(gl);
+  const program = createProgram(gl, VERTEX_SHADER, FRAGMENT_SHADER);
   gl.useProgram(program);
 
   const vao = gl.createVertexArray()!;
@@ -186,6 +209,48 @@ const setupGL = (canvas: HTMLCanvasElement): GLState | null => {
   const positionLoc = gl.getAttribLocation(program, "a_position");
   gl.enableVertexAttribArray(positionLoc);
   gl.vertexAttribPointer(positionLoc, 2, gl.FLOAT, false, 0, 0);
+
+  const postProgram = createProgram(
+    gl,
+    POST_VERTEX_SHADER,
+    POST_FRAGMENT_SHADER,
+  );
+  const postVao = gl.createVertexArray()!;
+  gl.bindVertexArray(postVao);
+  gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+  const postPositionLoc = gl.getAttribLocation(postProgram, "a_position");
+  gl.enableVertexAttribArray(postPositionLoc);
+  gl.vertexAttribPointer(postPositionLoc, 2, gl.FLOAT, false, 0, 0);
+  gl.bindVertexArray(vao);
+
+  const sceneTex = gl.createTexture()!;
+  gl.bindTexture(gl.TEXTURE_2D, sceneTex);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  const sceneFbo = gl.createFramebuffer()!;
+
+  const postUniforms = {
+    u_scene: gl.getUniformLocation(postProgram, "u_scene"),
+    u_resolution: gl.getUniformLocation(postProgram, "u_resolution"),
+    u_time: gl.getUniformLocation(postProgram, "u_time"),
+    u_blurMaxPx: gl.getUniformLocation(postProgram, "u_blurMaxPx"),
+    u_blurInner: gl.getUniformLocation(postProgram, "u_blurInner"),
+    u_blurOuter: gl.getUniformLocation(postProgram, "u_blurOuter"),
+    u_glitchInterval: gl.getUniformLocation(postProgram, "u_glitchInterval"),
+    u_glitchDuration: gl.getUniformLocation(postProgram, "u_glitchDuration"),
+    u_glitchShift: gl.getUniformLocation(postProgram, "u_glitchShift"),
+    u_glitchCaPx: gl.getUniformLocation(postProgram, "u_glitchCaPx"),
+  };
+  gl.useProgram(postProgram);
+  gl.uniform1i(postUniforms.u_scene, 3);
+  gl.uniform1f(postUniforms.u_blurInner, PLASMA_BLUR_INNER_FRAC);
+  gl.uniform1f(postUniforms.u_blurOuter, PLASMA_BLUR_OUTER_FRAC);
+  gl.uniform1f(postUniforms.u_glitchInterval, PLASMA_GLITCH_INTERVAL);
+  gl.uniform1f(postUniforms.u_glitchDuration, PLASMA_GLITCH_DURATION);
+  gl.uniform1f(postUniforms.u_glitchShift, PLASMA_GLITCH_SHIFT);
+  gl.useProgram(program);
 
   const atlas = buildGlyphAtlas(BASE_CHARACTERS);
   const glyphTex = createGlyphTexture(gl, atlas);
@@ -269,6 +334,13 @@ const setupGL = (canvas: HTMLCanvasElement): GLState | null => {
     luminanceTex,
     atlas,
     uniforms,
+    postProgram,
+    postVao,
+    postUniforms,
+    sceneTex,
+    sceneFbo,
+    sceneSize: { width: 0, height: 0 },
+    timeOrigin: performance.now(),
     rampLength: 0,
     lastRampSignature: "",
     lastLuminanceSize: { width: 0, height: 0 },
@@ -349,6 +421,36 @@ const uploadLuminance = (
   }
 };
 
+const ensureSceneTarget = (state: GLState, width: number, height: number) => {
+  const { gl } = state;
+  if (state.sceneSize.width === width && state.sceneSize.height === height) {
+    return;
+  }
+  gl.activeTexture(gl.TEXTURE3);
+  gl.bindTexture(gl.TEXTURE_2D, state.sceneTex);
+  gl.texImage2D(
+    gl.TEXTURE_2D,
+    0,
+    gl.RGBA8,
+    width,
+    height,
+    0,
+    gl.RGBA,
+    gl.UNSIGNED_BYTE,
+    null,
+  );
+  gl.bindFramebuffer(gl.FRAMEBUFFER, state.sceneFbo);
+  gl.framebufferTexture2D(
+    gl.FRAMEBUFFER,
+    gl.COLOR_ATTACHMENT0,
+    gl.TEXTURE_2D,
+    state.sceneTex,
+    0,
+  );
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  state.sceneSize = { width, height };
+};
+
 const bindAndDraw = (
   state: GLState,
   gridWidth: number,
@@ -358,7 +460,7 @@ const bindAndDraw = (
   atlasScale: number,
   bgColor: [number, number, number],
 ) => {
-  const { gl, uniforms } = state;
+  const { gl, uniforms, postUniforms } = state;
   gl.uniform2f(uniforms.u_gridSize, gridWidth, gridHeight);
   gl.uniform2f(uniforms.u_cellPx, cellWidth, cellHeight);
   gl.uniform1f(uniforms.u_atlasScale, atlasScale);
@@ -377,8 +479,32 @@ const bindAndDraw = (
   gl.activeTexture(gl.TEXTURE2);
   gl.bindTexture(gl.TEXTURE_2D, state.luminanceTex);
 
+  // Pass 1: glyph field into the offscreen scene texture.
+  const targetW = gl.drawingBufferWidth;
+  const targetH = gl.drawingBufferHeight;
+  ensureSceneTarget(state, targetW, targetH);
+  gl.bindFramebuffer(gl.FRAMEBUFFER, state.sceneFbo);
+  gl.viewport(0, 0, targetW, targetH);
   gl.bindVertexArray(state.vao);
   gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+
+  // Pass 2: edge blur + occasional glitch onto the canvas.
+  const dpr = typeof window === "undefined" ? 1 : window.devicePixelRatio || 1;
+  gl.useProgram(state.postProgram);
+  gl.activeTexture(gl.TEXTURE3);
+  gl.bindTexture(gl.TEXTURE_2D, state.sceneTex);
+  gl.uniform2f(postUniforms.u_resolution, targetW, targetH);
+  gl.uniform1f(
+    postUniforms.u_time,
+    (performance.now() - state.timeOrigin) / 1000,
+  );
+  gl.uniform1f(postUniforms.u_blurMaxPx, PLASMA_BLUR_MAX_PX * dpr);
+  gl.uniform1f(postUniforms.u_glitchCaPx, PLASMA_GLITCH_CA_PX * dpr);
+  gl.viewport(0, 0, targetW, targetH);
+  gl.bindVertexArray(state.postVao);
+  gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+  gl.useProgram(state.program);
 };
 
 export const PlasmaCanvasGL = forwardRef<
@@ -425,8 +551,12 @@ export const PlasmaCanvasGL = forwardRef<
       gl.deleteTexture(s.glyphTex);
       gl.deleteTexture(s.rampTex);
       gl.deleteTexture(s.luminanceTex);
+      gl.deleteTexture(s.sceneTex);
+      gl.deleteFramebuffer(s.sceneFbo);
       gl.deleteVertexArray(s.vao);
+      gl.deleteVertexArray(s.postVao);
       gl.deleteProgram(s.program);
+      gl.deleteProgram(s.postProgram);
       stateRef.current = null;
     };
   }, []);

--- a/src/components/Plasma/GL/PlasmaCanvasGL.tsx
+++ b/src/components/Plasma/GL/PlasmaCanvasGL.tsx
@@ -16,6 +16,7 @@ import {
   PLASMA_BLUR_INNER_FRAC,
   PLASMA_BLUR_MAX_PX,
   PLASMA_BLUR_OUTER_FRAC,
+  PLASMA_GLITCH_BANDS,
   PLASMA_GLITCH_TEAR_PX,
   PLASMA_GLITCH_DURATION,
   PLASMA_GLITCH_INTERVAL,
@@ -241,6 +242,7 @@ const setupGL = (canvas: HTMLCanvasElement): GLState | null => {
     u_glitchInterval: gl.getUniformLocation(postProgram, "u_glitchInterval"),
     u_glitchDuration: gl.getUniformLocation(postProgram, "u_glitchDuration"),
     u_glitchShift: gl.getUniformLocation(postProgram, "u_glitchShift"),
+    u_glitchBands: gl.getUniformLocation(postProgram, "u_glitchBands"),
     u_glitchTearPx: gl.getUniformLocation(postProgram, "u_glitchTearPx"),
   };
   gl.useProgram(postProgram);
@@ -250,6 +252,7 @@ const setupGL = (canvas: HTMLCanvasElement): GLState | null => {
   gl.uniform1f(postUniforms.u_glitchInterval, PLASMA_GLITCH_INTERVAL);
   gl.uniform1f(postUniforms.u_glitchDuration, PLASMA_GLITCH_DURATION);
   gl.uniform1f(postUniforms.u_glitchShift, PLASMA_GLITCH_SHIFT);
+  gl.uniform1f(postUniforms.u_glitchBands, PLASMA_GLITCH_BANDS);
   gl.useProgram(program);
 
   const atlas = buildGlyphAtlas(BASE_CHARACTERS);

--- a/src/components/Plasma/GL/PlasmaCanvasGL.tsx
+++ b/src/components/Plasma/GL/PlasmaCanvasGL.tsx
@@ -18,8 +18,6 @@ import {
   PLASMA_BLUR_OUTER_FRAC,
   PLASMA_GLITCH_BANDS,
   PLASMA_GLITCH_TEAR_PX,
-  PLASMA_GLITCH_DURATION,
-  PLASMA_GLITCH_INTERVAL,
   CENTER_YS,
   PLASMA_COMPLEXITY,
   PLASMA_LENS_BASE_RADIUS_FRAC,
@@ -45,6 +43,7 @@ import {
   POST_VERTEX_SHADER,
   VERTEX_SHADER,
 } from "./shaders";
+import { getGlitchState, GlitchState } from "./getGlitchState";
 
 export type PlasmaCanvasGLHandle = {
   renderPlasma: () => void;
@@ -58,6 +57,8 @@ export type PlasmaCanvasGLHandle = {
   emitRipple: (cellX: number, cellY: number) => void;
   setLensScale: (value: number) => number;
   getLensScale: () => number;
+  /** Current glitch-burst amplitude (0 = calm), gated by reduced motion. */
+  getGlitchIntensity: () => number;
 };
 
 export type PlasmaCanvasGLProps = {
@@ -241,22 +242,18 @@ const setupGL = (canvas: HTMLCanvasElement): GLState | null => {
   const postUniforms = {
     u_scene: gl.getUniformLocation(postProgram, "u_scene"),
     u_resolution: gl.getUniformLocation(postProgram, "u_resolution"),
-    u_time: gl.getUniformLocation(postProgram, "u_time"),
     u_blurMaxPx: gl.getUniformLocation(postProgram, "u_blurMaxPx"),
     u_blurInner: gl.getUniformLocation(postProgram, "u_blurInner"),
     u_blurOuter: gl.getUniformLocation(postProgram, "u_blurOuter"),
-    u_glitchInterval: gl.getUniformLocation(postProgram, "u_glitchInterval"),
-    u_glitchDuration: gl.getUniformLocation(postProgram, "u_glitchDuration"),
     u_glitchBands: gl.getUniformLocation(postProgram, "u_glitchBands"),
     u_glitchTearPx: gl.getUniformLocation(postProgram, "u_glitchTearPx"),
-    u_glitchEnabled: gl.getUniformLocation(postProgram, "u_glitchEnabled"),
+    u_glitchBurst: gl.getUniformLocation(postProgram, "u_glitchBurst"),
+    u_glitchSeed: gl.getUniformLocation(postProgram, "u_glitchSeed"),
   };
   gl.useProgram(postProgram);
   gl.uniform1i(postUniforms.u_scene, 3);
   gl.uniform1f(postUniforms.u_blurInner, PLASMA_BLUR_INNER_FRAC);
   gl.uniform1f(postUniforms.u_blurOuter, PLASMA_BLUR_OUTER_FRAC);
-  gl.uniform1f(postUniforms.u_glitchInterval, PLASMA_GLITCH_INTERVAL);
-  gl.uniform1f(postUniforms.u_glitchDuration, PLASMA_GLITCH_DURATION);
   gl.uniform1f(postUniforms.u_glitchBands, PLASMA_GLITCH_BANDS);
   gl.useProgram(program);
 
@@ -463,6 +460,12 @@ const ensureSceneTarget = (state: GLState, width: number, height: number) => {
   state.sceneSize = { width, height };
 };
 
+// Current glitch amplitude/seed for this canvas, gated by reduced motion.
+const currentGlitch = (state: GLState): GlitchState => {
+  if (state.reducedMotion?.matches) return { burst: 0, seed: 0 };
+  return getGlitchState((performance.now() - state.timeOrigin) / 1000);
+};
+
 const bindAndDraw = (
   state: GLState,
   gridWidth: number,
@@ -514,20 +517,15 @@ const bindAndDraw = (
 
   // Pass 2: edge blur + occasional glitch onto the canvas.
   const dpr = typeof window === "undefined" ? 1 : window.devicePixelRatio || 1;
+  const glitch = currentGlitch(state);
   gl.useProgram(state.postProgram);
   gl.activeTexture(gl.TEXTURE3);
   gl.bindTexture(gl.TEXTURE_2D, state.sceneTex);
   gl.uniform2f(postUniforms.u_resolution, targetW, targetH);
-  gl.uniform1f(
-    postUniforms.u_time,
-    (performance.now() - state.timeOrigin) / 1000,
-  );
   gl.uniform1f(postUniforms.u_blurMaxPx, PLASMA_BLUR_MAX_PX * dpr);
   gl.uniform1f(postUniforms.u_glitchTearPx, PLASMA_GLITCH_TEAR_PX * dpr);
-  gl.uniform1f(
-    postUniforms.u_glitchEnabled,
-    state.reducedMotion?.matches ? 0 : 1,
-  );
+  gl.uniform1f(postUniforms.u_glitchBurst, glitch.burst);
+  gl.uniform1f(postUniforms.u_glitchSeed, glitch.seed);
   gl.viewport(0, 0, targetW, targetH);
   gl.bindVertexArray(state.postVao);
   gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
@@ -740,6 +738,11 @@ export const PlasmaCanvasGL = forwardRef<
         const state = stateRef.current;
         if (!state) return PLASMA_LENS_SCALE_DEFAULT;
         return state.lensScale;
+      },
+      getGlitchIntensity: () => {
+        const state = stateRef.current;
+        if (!state) return 0;
+        return currentGlitch(state).burst;
       },
     }),
     [

--- a/src/components/Plasma/GL/PlasmaCanvasGL.tsx
+++ b/src/components/Plasma/GL/PlasmaCanvasGL.tsx
@@ -174,6 +174,7 @@ type GLState = {
   sceneFbo: WebGLFramebuffer;
   sceneSize: { width: number; height: number };
   timeOrigin: number;
+  reducedMotion: MediaQueryList | null;
   rampLength: number;
   lastRampSignature: string;
   lastLuminanceSize: { width: number; height: number };
@@ -242,6 +243,7 @@ const setupGL = (canvas: HTMLCanvasElement): GLState | null => {
     u_glitchDuration: gl.getUniformLocation(postProgram, "u_glitchDuration"),
     u_glitchBands: gl.getUniformLocation(postProgram, "u_glitchBands"),
     u_glitchTearPx: gl.getUniformLocation(postProgram, "u_glitchTearPx"),
+    u_glitchEnabled: gl.getUniformLocation(postProgram, "u_glitchEnabled"),
   };
   gl.useProgram(postProgram);
   gl.uniform1i(postUniforms.u_scene, 3);
@@ -341,6 +343,10 @@ const setupGL = (canvas: HTMLCanvasElement): GLState | null => {
     sceneFbo,
     sceneSize: { width: 0, height: 0 },
     timeOrigin: performance.now(),
+    reducedMotion:
+      typeof window === "undefined"
+        ? null
+        : window.matchMedia("(prefers-reduced-motion: reduce)"),
     rampLength: 0,
     lastRampSignature: "",
     lastLuminanceSize: { width: 0, height: 0 },
@@ -501,6 +507,10 @@ const bindAndDraw = (
   );
   gl.uniform1f(postUniforms.u_blurMaxPx, PLASMA_BLUR_MAX_PX * dpr);
   gl.uniform1f(postUniforms.u_glitchTearPx, PLASMA_GLITCH_TEAR_PX * dpr);
+  gl.uniform1f(
+    postUniforms.u_glitchEnabled,
+    state.reducedMotion?.matches ? 0 : 1,
+  );
   gl.viewport(0, 0, targetW, targetH);
   gl.bindVertexArray(state.postVao);
   gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);

--- a/src/components/Plasma/GL/PlasmaCanvasGL.tsx
+++ b/src/components/Plasma/GL/PlasmaCanvasGL.tsx
@@ -71,6 +71,12 @@ export type PlasmaCanvasGLProps = {
   className?: string;
   style?: CSSProperties;
   /**
+   * Runs the edge-blur + glitch post-process pass. Off by default, so the
+   * plain glyph field renders straight to the canvas. Only the landing
+   * hero opts in — the site background and playground stay unprocessed.
+   */
+  postProcess?: boolean;
+  /**
    * Fires with the underlying <canvas> on mount and `null` on unmount.
    * Lets consumers (e.g. OrbitControls) bind pointer/wheel events to the
    * actual canvas element, so overlay UI siblings keep their own clicks.
@@ -465,6 +471,7 @@ const bindAndDraw = (
   cellHeight: number,
   atlasScale: number,
   bgColor: [number, number, number],
+  postProcess: boolean,
 ) => {
   const { gl, uniforms, postUniforms } = state;
   gl.uniform2f(uniforms.u_gridSize, gridWidth, gridHeight);
@@ -485,9 +492,19 @@ const bindAndDraw = (
   gl.activeTexture(gl.TEXTURE2);
   gl.bindTexture(gl.TEXTURE_2D, state.luminanceTex);
 
-  // Pass 1: glyph field into the offscreen scene texture.
   const targetW = gl.drawingBufferWidth;
   const targetH = gl.drawingBufferHeight;
+
+  // No post-process: draw the glyph field straight to the canvas.
+  if (!postProcess) {
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.viewport(0, 0, targetW, targetH);
+    gl.bindVertexArray(state.vao);
+    gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+    return;
+  }
+
+  // Pass 1: glyph field into the offscreen scene texture.
   ensureSceneTarget(state, targetW, targetH);
   gl.bindFramebuffer(gl.FRAMEBUFFER, state.sceneFbo);
   gl.viewport(0, 0, targetW, targetH);
@@ -531,6 +548,7 @@ export const PlasmaCanvasGL = forwardRef<
     gridHeight,
     className,
     style,
+    postProcess = false,
     onCanvasReady,
   },
   ref,
@@ -667,6 +685,7 @@ export const PlasmaCanvasGL = forwardRef<
           cellSize,
           atlasScale,
           bgColor,
+          postProcess,
         );
       },
       renderLuminance: (luminance, width, height) => {
@@ -684,6 +703,7 @@ export const PlasmaCanvasGL = forwardRef<
           cellSize,
           atlasScale,
           bgColor,
+          postProcess,
         );
       },
       setCursor: (cellX, cellY) => {
@@ -730,6 +750,7 @@ export const PlasmaCanvasGL = forwardRef<
       cellWidth,
       cellSize,
       atlasScale,
+      postProcess,
     ],
   );
 

--- a/src/components/Plasma/GL/getGlitchState.ts
+++ b/src/components/Plasma/GL/getGlitchState.ts
@@ -1,0 +1,42 @@
+import { PLASMA_GLITCH_DURATION, PLASMA_GLITCH_INTERVAL } from "../constants";
+
+export type GlitchState = {
+  /** Burst amplitude, 0 when calm, ~0.35–1 during a sub-burst. */
+  burst: number;
+  /** Pattern seed; stable within a sub-burst, re-rolled at each one. */
+  seed: number;
+};
+
+const CALM: GlitchState = { burst: 0, seed: 0 };
+
+// Cheap 1D hash, mirrors the GLSL hash11 shape. Because this is now the sole
+// source of truth (the shader reads the result rather than recomputing it),
+// it does not need to bit-match GLSL float precision.
+const hash11 = (p: number): number => {
+  let x = p * 0.1031;
+  x -= Math.floor(x);
+  x *= x + 33.33;
+  x *= x + x;
+  return x - Math.floor(x);
+};
+
+/**
+ * Deterministic glitch schedule shared by the WebGL tear and the DOM link
+ * animation. One short burst per interval, placed at a hashed offset, then
+ * cut into 2–4 instantly-switching sub-bursts that each re-roll the pattern.
+ */
+export const getGlitchState = (timeSec: number): GlitchState => {
+  const slot = Math.floor(timeSec / PLASMA_GLITCH_INTERVAL);
+  const slotT = timeSec - slot * PLASMA_GLITCH_INTERVAL;
+  const start =
+    hash11(slot) * (PLASMA_GLITCH_INTERVAL - PLASMA_GLITCH_DURATION);
+  const local = slotT - start;
+  if (local < 0 || local >= PLASMA_GLITCH_DURATION) {
+    return CALM;
+  }
+  const subCount = 2 + Math.floor(hash11(slot * 2.17) * 3);
+  const sub = Math.floor((local / PLASMA_GLITCH_DURATION) * subCount);
+  const seed = slot * 17 + sub * 3.7;
+  const burst = 0.35 + 0.65 * hash11(seed * 7.13);
+  return { burst, seed };
+};

--- a/src/components/Plasma/GL/shaders.ts
+++ b/src/components/Plasma/GL/shaders.ts
@@ -214,14 +214,19 @@ void main() {
   float vignette = smoothstep(u_blurInner, u_blurOuter, edgeDist);
 
   // Occasional glitch burst: one short, randomly-placed window per interval.
+  // No easing — the tear appears and vanishes instantly. Each burst is cut
+  // into 2-4 sub-bursts, and every sub-burst re-rolls the tear pattern.
   float slot = floor(u_time / u_glitchInterval);
   float slotT = u_time - slot * u_glitchInterval;
   float start = hash11(slot) * (u_glitchInterval - u_glitchDuration);
   float local = slotT - start;
   float burst = 0.0;
+  float seed = 0.0;
   if (local >= 0.0 && local < u_glitchDuration) {
-    float envelope = sin(3.14159265 * local / u_glitchDuration);
-    burst = envelope * (0.35 + 0.65 * hash11(slot * 7.13));
+    float subCount = 2.0 + floor(hash11(slot * 2.17) * 3.0);
+    float sub = floor(local / u_glitchDuration * subCount);
+    seed = slot * 17.0 + sub * 3.7;
+    burst = 0.35 + 0.65 * hash11(seed * 7.13);
   }
 
   // Radial blur: zero in the center, ramping up towards the frame edges.
@@ -240,9 +245,9 @@ void main() {
     // and cyan (green + blue) the other, each band with its own random
     // strength and pull direction. Everything outside a torn band stays put.
     float band = floor(v_uv.y * u_glitchBands);
-    float bandOn = step(0.55, hash21(vec2(band, slot)));
-    float bandAmp = 0.3 + 0.7 * hash21(vec2(band * 3.7, slot + 13.7));
-    float bandSign = sign(hash21(vec2(band * 9.1, slot + 41.3)) - 0.5);
+    float bandOn = step(0.55, hash21(vec2(band, seed)));
+    float bandAmp = 0.3 + 0.7 * hash21(vec2(band * 3.7, seed + 13.7));
+    float bandSign = sign(hash21(vec2(band * 9.1, seed + 41.3)) - 0.5);
     float tear =
       bandOn * bandSign * bandAmp * u_glitchTearPx * texel.x * burst;
     if (tear != 0.0) {

--- a/src/components/Plasma/GL/shaders.ts
+++ b/src/components/Plasma/GL/shaders.ts
@@ -177,22 +177,15 @@ out vec4 fragColor;
 
 uniform sampler2D u_scene;
 uniform vec2 u_resolution;
-uniform float u_time;
 uniform float u_blurMaxPx;
 uniform float u_blurInner;
 uniform float u_blurOuter;
-uniform float u_glitchInterval;
-uniform float u_glitchDuration;
 uniform float u_glitchBands;
 uniform float u_glitchTearPx;
-uniform float u_glitchEnabled;
-
-float hash11(float p) {
-  p = fract(p * 0.1031);
-  p *= p + 33.33;
-  p *= p + p;
-  return fract(p);
-}
+// Burst amplitude (0 = calm) and pattern seed, both driven from JS so the
+// canvas tear and the DOM link animation stay perfectly in sync.
+uniform float u_glitchBurst;
+uniform float u_glitchSeed;
 
 float hash21(vec2 p) {
   vec3 p3 = fract(vec3(p.xyx) * 0.1031);
@@ -214,21 +207,11 @@ void main() {
   float edgeDist = length((v_uv - 0.5) * 2.0);
   float vignette = smoothstep(u_blurInner, u_blurOuter, edgeDist);
 
-  // Occasional glitch burst: one short, randomly-placed window per interval.
-  // No easing — the tear appears and vanishes instantly. Each burst is cut
-  // into 2-4 sub-bursts, and every sub-burst re-rolls the tear pattern.
-  float slot = floor(u_time / u_glitchInterval);
-  float slotT = u_time - slot * u_glitchInterval;
-  float start = hash11(slot) * (u_glitchInterval - u_glitchDuration);
-  float local = slotT - start;
-  float burst = 0.0;
-  float seed = 0.0;
-  if (u_glitchEnabled > 0.5 && local >= 0.0 && local < u_glitchDuration) {
-    float subCount = 2.0 + floor(hash11(slot * 2.17) * 3.0);
-    float sub = floor(local / u_glitchDuration * subCount);
-    seed = slot * 17.0 + sub * 3.7;
-    burst = 0.35 + 0.65 * hash11(seed * 7.13);
-  }
+  // Burst amplitude and pattern seed are computed on the JS side (see
+  // getGlitchState) and passed straight in, so the letter animation can
+  // read the exact same value.
+  float burst = u_glitchBurst;
+  float seed = u_glitchSeed;
 
   // Radial blur: zero in the center, ramping up towards the frame edges.
   vec2 texel = 1.0 / u_resolution;

--- a/src/components/Plasma/GL/shaders.ts
+++ b/src/components/Plasma/GL/shaders.ts
@@ -156,3 +156,100 @@ void main() {
   fragColor = vec4(mix(u_bgColor, color, alpha), 1.0);
 }
 `;
+
+export const POST_VERTEX_SHADER = `#version 300 es
+precision highp float;
+
+in vec2 a_position;
+out vec2 v_uv;
+
+void main() {
+  v_uv = a_position * 0.5 + 0.5;
+  gl_Position = vec4(a_position, 0.0, 1.0);
+}
+`;
+
+export const POST_FRAGMENT_SHADER = `#version 300 es
+precision highp float;
+
+in vec2 v_uv;
+out vec4 fragColor;
+
+uniform sampler2D u_scene;
+uniform vec2 u_resolution;
+uniform float u_time;
+uniform float u_blurMaxPx;
+uniform float u_blurInner;
+uniform float u_blurOuter;
+uniform float u_glitchInterval;
+uniform float u_glitchDuration;
+uniform float u_glitchShift;
+uniform float u_glitchCaPx;
+
+float hash11(float p) {
+  p = fract(p * 0.1031);
+  p *= p + 33.33;
+  p *= p + p;
+  return fract(p);
+}
+
+float hash21(vec2 p) {
+  vec3 p3 = fract(vec3(p.xyx) * 0.1031);
+  p3 += dot(p3, p3.yzx + 33.33);
+  return fract((p3.x + p3.y) * p3.z);
+}
+
+const vec2 RING_INNER[4] = vec2[4](
+  vec2(1.0, 0.0), vec2(-1.0, 0.0), vec2(0.0, 1.0), vec2(0.0, -1.0)
+);
+const vec2 RING_OUTER[8] = vec2[8](
+  vec2(1.0, 0.0), vec2(-1.0, 0.0), vec2(0.0, 1.0), vec2(0.0, -1.0),
+  vec2(0.7071, 0.7071), vec2(-0.7071, 0.7071),
+  vec2(0.7071, -0.7071), vec2(-0.7071, -0.7071)
+);
+
+void main() {
+  vec2 uv = v_uv;
+  float edgeDist = length((v_uv - 0.5) * 2.0);
+  float vignette = smoothstep(u_blurInner, u_blurOuter, edgeDist);
+
+  // Occasional glitch burst: one short, randomly-placed window per interval.
+  float slot = floor(u_time / u_glitchInterval);
+  float slotT = u_time - slot * u_glitchInterval;
+  float start = hash11(slot) * (u_glitchInterval - u_glitchDuration);
+  float local = slotT - start;
+  float burst = 0.0;
+  if (local >= 0.0 && local < u_glitchDuration) {
+    float envelope = sin(3.14159265 * local / u_glitchDuration);
+    burst = envelope * (0.35 + 0.65 * hash11(slot * 7.13));
+  }
+
+  if (burst > 0.0) {
+    float band = floor(uv.y * 28.0);
+    float frame = floor(u_time * 24.0);
+    float bandOn = step(0.8, hash21(vec2(band, frame)));
+    float shift = (hash21(vec2(band * 3.7, frame)) - 0.5) * 2.0;
+    uv.x += bandOn * shift * u_glitchShift * burst;
+  }
+
+  // Radial blur: zero in the center, ramping up towards the frame edges.
+  vec2 texel = 1.0 / u_resolution;
+  float radius = u_blurMaxPx * vignette;
+  vec3 col = texture(u_scene, uv).rgb * 0.22;
+  for (int i = 0; i < 4; i++) {
+    col += texture(u_scene, uv + RING_INNER[i] * texel * radius * 0.5).rgb * 0.1;
+  }
+  for (int i = 0; i < 8; i++) {
+    col += texture(u_scene, uv + RING_OUTER[i] * texel * radius).rgb * 0.0475;
+  }
+
+  if (burst > 0.0) {
+    // Chromatic aberration, slightly stronger away from the center.
+    float ca = u_glitchCaPx * texel.x * burst * (0.5 + 0.5 * vignette);
+    col.r = mix(col.r, texture(u_scene, uv + vec2(ca, 0.0)).r, 0.8);
+    col.b = mix(col.b, texture(u_scene, uv - vec2(ca, 0.0)).b, 0.8);
+  }
+
+  fragColor = vec4(col, 1.0);
+}
+`;

--- a/src/components/Plasma/GL/shaders.ts
+++ b/src/components/Plasma/GL/shaders.ts
@@ -183,7 +183,6 @@ uniform float u_blurInner;
 uniform float u_blurOuter;
 uniform float u_glitchInterval;
 uniform float u_glitchDuration;
-uniform float u_glitchShift;
 uniform float u_glitchBands;
 uniform float u_glitchTearPx;
 
@@ -225,14 +224,6 @@ void main() {
     burst = envelope * (0.35 + 0.65 * hash11(slot * 7.13));
   }
 
-  if (burst > 0.0) {
-    float band = floor(uv.y * u_glitchBands);
-    float frame = floor(u_time * 24.0);
-    float bandOn = step(0.8, hash21(vec2(band, frame)));
-    float shift = (hash21(vec2(band * 3.7, frame)) - 0.5) * 2.0;
-    uv.x += bandOn * shift * u_glitchShift * burst;
-  }
-
   // Radial blur: zero in the center, ramping up towards the frame edges.
   vec2 texel = 1.0 / u_resolution;
   float radius = u_blurMaxPx * vignette;
@@ -245,16 +236,20 @@ void main() {
   }
 
   if (burst > 0.0) {
-    // Anaglyph tear: red pulled one way, cyan (green + blue) the opposite
-    // way, so bright glyphs briefly rip into a red and a cyan ghost. Each
-    // burst tears in its own random direction and with its own strength.
-    float angle = hash11(slot * 3.31) * 6.2831853;
-    float tearAmp = 0.3 + 0.7 * hash11(slot * 5.77);
-    vec2 dir = vec2(cos(angle), sin(angle));
-    vec2 tear = dir * texel * u_glitchTearPx * burst * tearAmp;
-    vec3 redSide = texture(u_scene, uv + tear).rgb;
-    vec3 cyanSide = texture(u_scene, uv - tear).rgb;
-    col = vec3(redSide.r, cyanSide.g, cyanSide.b);
+    // Band tear: only some horizontal bands rip apart, red pulled one way
+    // and cyan (green + blue) the other, each band with its own random
+    // strength and pull direction. Everything outside a torn band stays put.
+    float band = floor(v_uv.y * u_glitchBands);
+    float bandOn = step(0.55, hash21(vec2(band, slot)));
+    float bandAmp = 0.3 + 0.7 * hash21(vec2(band * 3.7, slot + 13.7));
+    float bandSign = sign(hash21(vec2(band * 9.1, slot + 41.3)) - 0.5);
+    float tear =
+      bandOn * bandSign * bandAmp * u_glitchTearPx * texel.x * burst;
+    if (tear != 0.0) {
+      vec3 redSide = texture(u_scene, uv + vec2(tear, 0.0)).rgb;
+      vec3 cyanSide = texture(u_scene, uv - vec2(tear, 0.0)).rgb;
+      col = vec3(redSide.r, cyanSide.g, cyanSide.b);
+    }
   }
 
   fragColor = vec4(col, 1.0);

--- a/src/components/Plasma/GL/shaders.ts
+++ b/src/components/Plasma/GL/shaders.ts
@@ -185,6 +185,7 @@ uniform float u_glitchInterval;
 uniform float u_glitchDuration;
 uniform float u_glitchBands;
 uniform float u_glitchTearPx;
+uniform float u_glitchEnabled;
 
 float hash11(float p) {
   p = fract(p * 0.1031);
@@ -222,7 +223,7 @@ void main() {
   float local = slotT - start;
   float burst = 0.0;
   float seed = 0.0;
-  if (local >= 0.0 && local < u_glitchDuration) {
+  if (u_glitchEnabled > 0.5 && local >= 0.0 && local < u_glitchDuration) {
     float subCount = 2.0 + floor(hash11(slot * 2.17) * 3.0);
     float sub = floor(local / u_glitchDuration * subCount);
     seed = slot * 17.0 + sub * 3.7;

--- a/src/components/Plasma/GL/shaders.ts
+++ b/src/components/Plasma/GL/shaders.ts
@@ -246,11 +246,12 @@ void main() {
 
   if (burst > 0.0) {
     // Anaglyph tear: red pulled one way, cyan (green + blue) the opposite
-    // way, so bright glyphs briefly rip into a red and a cyan ghost. The
-    // tear direction wobbles a little from burst to burst.
-    float angle = (hash11(slot * 3.31) - 0.5) * 0.3;
+    // way, so bright glyphs briefly rip into a red and a cyan ghost. Each
+    // burst tears in its own random direction and with its own strength.
+    float angle = hash11(slot * 3.31) * 6.2831853;
+    float tearAmp = 0.3 + 0.7 * hash11(slot * 5.77);
     vec2 dir = vec2(cos(angle), sin(angle));
-    vec2 tear = dir * texel * u_glitchTearPx * burst;
+    vec2 tear = dir * texel * u_glitchTearPx * burst * tearAmp;
     vec3 redSide = texture(u_scene, uv + tear).rgb;
     vec3 cyanSide = texture(u_scene, uv - tear).rgb;
     col = vec3(redSide.r, cyanSide.g, cyanSide.b);

--- a/src/components/Plasma/GL/shaders.ts
+++ b/src/components/Plasma/GL/shaders.ts
@@ -184,6 +184,7 @@ uniform float u_blurOuter;
 uniform float u_glitchInterval;
 uniform float u_glitchDuration;
 uniform float u_glitchShift;
+uniform float u_glitchBands;
 uniform float u_glitchTearPx;
 
 float hash11(float p) {
@@ -225,7 +226,7 @@ void main() {
   }
 
   if (burst > 0.0) {
-    float band = floor(uv.y * 28.0);
+    float band = floor(uv.y * u_glitchBands);
     float frame = floor(u_time * 24.0);
     float bandOn = step(0.8, hash21(vec2(band, frame)));
     float shift = (hash21(vec2(band * 3.7, frame)) - 0.5) * 2.0;
@@ -247,7 +248,7 @@ void main() {
     // Anaglyph tear: red pulled one way, cyan (green + blue) the opposite
     // way, so bright glyphs briefly rip into a red and a cyan ghost. The
     // tear direction wobbles a little from burst to burst.
-    float angle = (hash11(slot * 3.31) - 0.5) * 0.5;
+    float angle = (hash11(slot * 3.31) - 0.5) * 0.3;
     vec2 dir = vec2(cos(angle), sin(angle));
     vec2 tear = dir * texel * u_glitchTearPx * burst;
     vec3 redSide = texture(u_scene, uv + tear).rgb;

--- a/src/components/Plasma/GL/shaders.ts
+++ b/src/components/Plasma/GL/shaders.ts
@@ -184,7 +184,7 @@ uniform float u_blurOuter;
 uniform float u_glitchInterval;
 uniform float u_glitchDuration;
 uniform float u_glitchShift;
-uniform float u_glitchCaPx;
+uniform float u_glitchTearPx;
 
 float hash11(float p) {
   p = fract(p * 0.1031);
@@ -244,10 +244,15 @@ void main() {
   }
 
   if (burst > 0.0) {
-    // Chromatic aberration, slightly stronger away from the center.
-    float ca = u_glitchCaPx * texel.x * burst * (0.5 + 0.5 * vignette);
-    col.r = mix(col.r, texture(u_scene, uv + vec2(ca, 0.0)).r, 0.8);
-    col.b = mix(col.b, texture(u_scene, uv - vec2(ca, 0.0)).b, 0.8);
+    // Anaglyph tear: red pulled one way, cyan (green + blue) the opposite
+    // way, so bright glyphs briefly rip into a red and a cyan ghost. The
+    // tear direction wobbles a little from burst to burst.
+    float angle = (hash11(slot * 3.31) - 0.5) * 0.5;
+    vec2 dir = vec2(cos(angle), sin(angle));
+    vec2 tear = dir * texel * u_glitchTearPx * burst;
+    vec3 redSide = texture(u_scene, uv + tear).rgb;
+    vec3 cyanSide = texture(u_scene, uv - tear).rgb;
+    col = vec3(redSide.r, cyanSide.g, cyanSide.b);
   }
 
   fragColor = vec4(col, 1.0);

--- a/src/components/Plasma/LabelOverlay.tsx
+++ b/src/components/Plasma/LabelOverlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CSSProperties } from "react";
+import { CSSProperties, ReactNode, useEffect, useRef } from "react";
 import Link from "next/link";
 import { LabelPlacement } from "./getLabelGroupPlacements";
 
@@ -9,6 +9,80 @@ type LabelOverlayProps = {
   cellSize: number;
   cellWidth?: number;
   fontPx: number;
+  /**
+   * Live glitch-burst amplitude (0 = calm). When provided, labels flagged
+   * with `glitch` mirror the canvas tear as a red/cyan text split in sync.
+   */
+  getGlitchIntensity?: () => number;
+};
+
+// How strongly the split holds while hovered/focused, and how fast it eases
+// toward that hold each frame.
+const HOVER_HOLD = 0.6;
+const HOVER_EASE = 0.18;
+
+// Red one way, cyan the other — the same anaglyph tear the canvas uses. Both
+// the offset and the opacity scale with the live `--glitch` value, so at rest
+// (0) the shadow is invisible and no layout box changes.
+const glitchShadowStyle = {
+  "--glitch": 0,
+  textShadow:
+    "calc(var(--glitch, 0) * 0.16em) 0 rgba(255, 0, 0, calc(var(--glitch, 0))), " +
+    "calc(var(--glitch, 0) * -0.16em) 0 rgba(0, 255, 255, calc(var(--glitch, 0)))",
+} as CSSProperties;
+
+type GlitchLinkProps = {
+  href: string;
+  ariaLabel: string;
+  className?: string;
+  style?: CSSProperties;
+  onClick?: () => void;
+  getIntensity: () => number;
+  children: ReactNode;
+};
+
+const GlitchLink = ({
+  href,
+  ariaLabel,
+  className,
+  style,
+  onClick,
+  getIntensity,
+  children,
+}: GlitchLinkProps) => {
+  const ref = useRef<HTMLAnchorElement>(null);
+  const hoverRef = useRef(false);
+  const easeRef = useRef(0);
+
+  useEffect(() => {
+    let raf = 0;
+    const tick = () => {
+      const target = hoverRef.current ? HOVER_HOLD : 0;
+      easeRef.current += (target - easeRef.current) * HOVER_EASE;
+      const value = Math.max(getIntensity(), easeRef.current);
+      ref.current?.style.setProperty("--glitch", value.toFixed(3));
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [getIntensity]);
+
+  return (
+    <Link
+      ref={ref}
+      href={href}
+      aria-label={ariaLabel}
+      className={className}
+      style={{ ...style, ...glitchShadowStyle }}
+      onClick={onClick}
+      onPointerEnter={() => (hoverRef.current = true)}
+      onPointerLeave={() => (hoverRef.current = false)}
+      onFocus={() => (hoverRef.current = true)}
+      onBlur={() => (hoverRef.current = false)}
+    >
+      {children}
+    </Link>
+  );
 };
 
 export const LabelOverlay = ({
@@ -16,6 +90,7 @@ export const LabelOverlay = ({
   cellSize,
   cellWidth,
   fontPx,
+  getGlitchIntensity,
 }: LabelOverlayProps) => {
   const cw = cellWidth ?? cellSize;
   const ch = cellSize;
@@ -50,6 +125,22 @@ export const LabelOverlay = ({
             {character}
           </span>
         ));
+
+        if (label.href && label.glitch && getGlitchIntensity) {
+          return (
+            <GlitchLink
+              key={idx}
+              href={label.href}
+              ariaLabel={label.label}
+              className={className}
+              style={containerStyle}
+              onClick={label.onClick}
+              getIntensity={getGlitchIntensity}
+            >
+              {content}
+            </GlitchLink>
+          );
+        }
 
         if (label.href) {
           return (

--- a/src/components/Plasma/PlasmaCanvas.tsx
+++ b/src/components/Plasma/PlasmaCanvas.tsx
@@ -45,6 +45,11 @@ export type PlasmaCanvasProps = {
   className?: string;
   style?: CSSProperties;
   /**
+   * Runs the edge-blur + glitch post-process pass (WebGL2 path only). Off
+   * by default; the landing hero is the only consumer that enables it.
+   */
+  postProcess?: boolean;
+  /**
    * Called from the JS fallback path with the freshly-computed glyph grid,
    * before it is drawn. The callback may mutate the frame in place (e.g. to
    * blank cells under DOM label overlays) and/or capture it for later use.
@@ -71,6 +76,7 @@ export const PlasmaCanvas = forwardRef<PlasmaCanvasHandle, PlasmaCanvasProps>(
       gridHeight,
       className,
       style,
+      postProcess,
       onTextFrame,
       onCanvasReady,
     } = props;
@@ -164,6 +170,7 @@ export const PlasmaCanvas = forwardRef<PlasmaCanvasHandle, PlasmaCanvasProps>(
           gridHeight={gridHeight}
           className={className}
           style={style}
+          postProcess={postProcess}
           onCanvasReady={onCanvasReady}
         />
       );

--- a/src/components/Plasma/PlasmaCanvas.tsx
+++ b/src/components/Plasma/PlasmaCanvas.tsx
@@ -32,6 +32,7 @@ export type PlasmaCanvasHandle = {
   emitRipple: (cellX: number, cellY: number) => void;
   setLensScale: (value: number) => number;
   getLensScale: () => number;
+  getGlitchIntensity: () => number;
 };
 
 export type PlasmaCanvasProps = {
@@ -149,6 +150,7 @@ export const PlasmaCanvas = forwardRef<PlasmaCanvasHandle, PlasmaCanvasProps>(
         },
         setLensScale: (value) => glRef.current?.setLensScale(value) ?? value,
         getLensScale: () => glRef.current?.getLensScale() ?? 1,
+        getGlitchIntensity: () => glRef.current?.getGlitchIntensity() ?? 0,
       }),
       [supportsGL, renderPlasmaJS, renderLuminanceJS],
     );

--- a/src/components/Plasma/constants.ts
+++ b/src/components/Plasma/constants.ts
@@ -58,7 +58,7 @@ export const PLASMA_BLUR_OUTER_FRAC = 1.15;
 export const PLASMA_GLITCH_INTERVAL = 5.0;
 export const PLASMA_GLITCH_DURATION = 0.3;
 export const PLASMA_GLITCH_SHIFT = 0.008;
-export const PLASMA_GLITCH_CA_PX = 2.0;
+export const PLASMA_GLITCH_TEAR_PX = 7.0;
 
 export const PLASMA_RIPPLE_MAX = 6;
 export const PLASMA_RIPPLE_RADIUS_FRAC = 0.4;

--- a/src/components/Plasma/constants.ts
+++ b/src/components/Plasma/constants.ts
@@ -57,7 +57,6 @@ export const PLASMA_BLUR_INNER_FRAC = 0.35;
 export const PLASMA_BLUR_OUTER_FRAC = 1.15;
 export const PLASMA_GLITCH_INTERVAL = 5.0;
 export const PLASMA_GLITCH_DURATION = 0.3;
-export const PLASMA_GLITCH_SHIFT = 0.008;
 export const PLASMA_GLITCH_BANDS = 12.0;
 export const PLASMA_GLITCH_TEAR_PX = 12.0;
 

--- a/src/components/Plasma/constants.ts
+++ b/src/components/Plasma/constants.ts
@@ -52,13 +52,14 @@ export const PLASMA_LANDING_LENS_Y_FRAC = 0.48;
 
 // Post-process pass: radial blur (none in the center, more towards the
 // edges) plus a short glitch burst every few seconds.
-export const PLASMA_BLUR_MAX_PX = 3.0;
+export const PLASMA_BLUR_MAX_PX = 5.0;
 export const PLASMA_BLUR_INNER_FRAC = 0.35;
 export const PLASMA_BLUR_OUTER_FRAC = 1.15;
 export const PLASMA_GLITCH_INTERVAL = 5.0;
 export const PLASMA_GLITCH_DURATION = 0.3;
 export const PLASMA_GLITCH_SHIFT = 0.008;
-export const PLASMA_GLITCH_TEAR_PX = 7.0;
+export const PLASMA_GLITCH_BANDS = 12.0;
+export const PLASMA_GLITCH_TEAR_PX = 12.0;
 
 export const PLASMA_RIPPLE_MAX = 6;
 export const PLASMA_RIPPLE_RADIUS_FRAC = 0.4;

--- a/src/components/Plasma/constants.ts
+++ b/src/components/Plasma/constants.ts
@@ -50,6 +50,16 @@ export const PLASMA_LANDING_LENS_SCALE = 3;
 export const PLASMA_LANDING_LENS_X_FRAC = 0.5;
 export const PLASMA_LANDING_LENS_Y_FRAC = 0.48;
 
+// Post-process pass: radial blur (none in the center, more towards the
+// edges) plus a short glitch burst every few seconds.
+export const PLASMA_BLUR_MAX_PX = 3.0;
+export const PLASMA_BLUR_INNER_FRAC = 0.35;
+export const PLASMA_BLUR_OUTER_FRAC = 1.15;
+export const PLASMA_GLITCH_INTERVAL = 5.0;
+export const PLASMA_GLITCH_DURATION = 0.3;
+export const PLASMA_GLITCH_SHIFT = 0.008;
+export const PLASMA_GLITCH_CA_PX = 2.0;
+
 export const PLASMA_RIPPLE_MAX = 6;
 export const PLASMA_RIPPLE_RADIUS_FRAC = 0.4;
 export const PLASMA_RIPPLE_STRENGTH = 4.0;

--- a/src/components/Plasma/types.ts
+++ b/src/components/Plasma/types.ts
@@ -13,7 +13,11 @@ export type Glyph = {
   onClick?: () => void;
 };
 
-export type Label = Omit<Glyph, "character"> & { label: string };
+export type Label = Omit<Glyph, "character"> & {
+  label: string;
+  /** Sync a chromatic red/cyan tear on this label with the canvas glitch. */
+  glitch?: boolean;
+};
 
 export type LabelGroup = {
   labels: Label[];

--- a/src/components/PlasmaLanding/PlasmaLanding.tsx
+++ b/src/components/PlasmaLanding/PlasmaLanding.tsx
@@ -127,6 +127,7 @@ const Frame = ({ bounds, cellSize, fontPx }: FrameProps) => {
         fontPx={fontPx}
         gridWidth={bounds.width}
         gridHeight={bounds.height}
+        postProcess
       />
       <LabelOverlay
         placements={placements}

--- a/src/components/PlasmaLanding/PlasmaLanding.tsx
+++ b/src/components/PlasmaLanding/PlasmaLanding.tsx
@@ -79,6 +79,11 @@ const Frame = ({ bounds, cellSize, fontPx }: FrameProps) => {
     return getResponsivePlacements(bounds, groups);
   }, [bounds, isPlaying, fontPx]);
 
+  const getGlitchIntensity = useCallback(
+    () => (isPlaying ? (canvasRef.current?.getGlitchIntensity() ?? 0) : 0),
+    [isPlaying],
+  );
+
   const applyStaticLens = useCallback(() => {
     if (!bounds) {
       return;
@@ -133,6 +138,7 @@ const Frame = ({ bounds, cellSize, fontPx }: FrameProps) => {
         placements={placements}
         cellSize={cellSize}
         fontPx={fontPx}
+        getGlitchIntensity={getGlitchIntensity}
       />
     </div>
   );

--- a/src/components/PlasmaLanding/labelGroups.ts
+++ b/src/components/PlasmaLanding/labelGroups.ts
@@ -63,6 +63,7 @@ const getCenterLabelGroup = (fontPx: number): LabelGroup => ({
         fontSize: fontPx + CENTER_FONT_BOOST_PX,
       },
       href: "/cv",
+      glitch: true,
     },
   ],
   yAlign: "center",


### PR DESCRIPTION
Adds a post-process pass to the landing plasma hero: a subtle edge blur plus an occasional anaglyph "signal tear" glitch, with the main **FUERST.ONE** link animating in sync.

## What's included

**Edge blur** — sharp in the center, ramping up to ~5px toward the frame edges (12-tap two-ring kernel driven by a vignette).

**Glitch tear** — every ~5s, a short burst instantly appears and vanishes (no easing). Each burst is cut into 2–4 sub-bursts that each re-roll the pattern. Only some horizontal bands tear, each ripping into a red/cyan anaglyph split with its own random strength and pull direction; untorn bands stay anchored.

**Synced link animation** — the glitch schedule now lives in one shared JS module (`getGlitchState`) that is the single source of truth; the shader receives the burst amplitude and seed as uniforms rather than recomputing them. The center FUERST.ONE link polls `getGlitchIntensity()` via `requestAnimationFrame` and mirrors the tear as a red/cyan `text-shadow` split in lockstep with the background. Hover/focus eases the split into a gentle hold to reinforce that it's the primary link.

## Scope & accessibility

- **Landing only** — the whole effect is behind an opt-in `postProcess` prop (default off). The site background behind the CV/contact/legal pages and the `/plasma` playground render unprocessed, exactly as before.
- **Reduced motion** — `prefers-reduced-motion: reduce` zeroes the burst for both the canvas and the link; the static edge blur is unaffected.

All tunables (blur radius, interval, duration, band count, tear width) are constants in `src/components/Plasma/constants.ts`. The JS fallback renderer is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDTakAiWobT87iYK1KRBUZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDTakAiWobT87iYK1KRBUZ)_